### PR TITLE
Fix rake task when having a wildcard domain in heroku config

### DIFF
--- a/lib/tasks/letsencrypt.rake
+++ b/lib/tasks/letsencrypt.rake
@@ -51,7 +51,7 @@ namespace :letsencrypt do
       print "Testing filename works (to bring up app)..."
 
       # Get the domain name from Heroku
-      hostname = heroku.domain.list(heroku_app).first['hostname']
+      hostname = heroku.domain.list(heroku_app).last['hostname']
       open("http://#{hostname}/#{challenge.filename}").read
       puts "Done!"
 


### PR DESCRIPTION
Use last heroku domain name to avoid an exception when running heroku run rake letsencrypt:renew while having a wildcard domain in the heroku configuration

Example:

```
heroku run rake letsencrypt:renew --remote production
/usr/local/heroku/lib/heroku/jsplugin.rb:88: warning: Insecure world writable dir /home/vagrant/.rvm/gems/ruby-2.4.0@rails5/bin in PATH, mode 040777
Running rake letsencrypt:renew on ⬢ mysterious-plains-28931... up, run.7653 (Hobby)
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.1/lib/active_support/xml_mini.rb:51: warning: constant ::Fixnum is deprecated
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.1/lib/active_support/xml_mini.rb:52: warning: constant ::Bignum is deprecated
Creating account key...Done!
Registering with LetsEncrypt...Done!
Performing verification for www.my-domain.com:
Setting config vars on Heroku...Done!
Giving config vars time to change...Done!
Testing filename works (to bring up app)...rake aborted!
SocketError: Failed to open TCP connection to *.my-domain.com:80 (getaddrinfo: Name or service not known)
/app/vendor/bundle/ruby/2.4.0/gems/letsencrypt-rails-heroku-0.3.0/lib/tasks/letsencrypt.rake:55:in `block (3 levels) in <top (required)>'
/app/vendor/bundle/ruby/2.4.0/gems/letsencrypt-rails-heroku-0.3.0/lib/tasks/letsencrypt.rake:32:in `each'
/app/vendor/bundle/ruby/2.4.0/gems/letsencrypt-rails-heroku-0.3.0/lib/tasks/letsencrypt.rake:32:in `block (2 levels) in <top (required)>'
/app/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `load'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `kernel_load'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:27:in `run'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:332:in `exec'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:20:in `dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:11:in `start'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/exe/bundle:34:in `block in <top (required)>'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/exe/bundle:26:in `<top (required)>'
/app/bin/bundle:3:in `load'
/app/bin/bundle:3:in `<main>'
SocketError: getaddrinfo: Name or service not known
/app/vendor/bundle/ruby/2.4.0/gems/letsencrypt-rails-heroku-0.3.0/lib/tasks/letsencrypt.rake:55:in `block (3 levels) in <top (required)>'
/app/vendor/bundle/ruby/2.4.0/gems/letsencrypt-rails-heroku-0.3.0/lib/tasks/letsencrypt.rake:32:in `each'
/app/vendor/bundle/ruby/2.4.0/gems/letsencrypt-rails-heroku-0.3.0/lib/tasks/letsencrypt.rake:32:in `block (2 levels) in <top (required)>'
/app/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `load'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `kernel_load'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:27:in `run'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:332:in `exec'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:20:in `dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:11:in `start'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/exe/bundle:34:in `block in <top (required)>'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
/app/vendor/bundle/ruby/2.4.0/gems/bundler-1.13.7/exe/bundle:26:in `<top (required)>'
/app/bin/bundle:3:in `load'
/app/bin/bundle:3:in `<main>'
Tasks: TOP => letsencrypt:renew
(See full trace by running task with --trace)

```