### PR TITLE
Retries challenge URL

### DIFF
--- a/lib/letsencrypt-rails-heroku.rb
+++ b/lib/letsencrypt-rails-heroku.rb
@@ -1,5 +1,6 @@
 require 'letsencrypt-rails-heroku/letsencrypt'
 require 'letsencrypt-rails-heroku/middleware'
+require 'letsencrypt-rails-heroku/exceptions'
 
 if defined?(Rails)
   require 'letsencrypt-rails-heroku/railtie'

--- a/lib/letsencrypt-rails-heroku/exceptions.rb
+++ b/lib/letsencrypt-rails-heroku/exceptions.rb
@@ -1,0 +1,10 @@
+module Letsencrypt
+  module Error
+    # Exception raised when LetsEncrypt encounters an issue verifying the challenge.
+    class VerificationError < StandardError; end
+    # Exception raised when an error occurs adding the certificate to Heroku.
+    class HerokuCertError < StandardError; end
+    # Exception raised when challenge URL is not available.
+    class ChallengeUrlError < StandardError; end
+  end
+end

--- a/lib/tasks/letsencrypt.rake
+++ b/lib/tasks/letsencrypt.rake
@@ -8,7 +8,7 @@ namespace :letsencrypt do
   desc 'Renew your LetsEncrypt certificate'
   task :renew do
     # Check configuration looks OK
-    abort "letsencrypt-rails-heroku is configured incorrectly. Are you missing an environment variable or other configuration? You should have a heroku_token, heroku_app, acmp_email and acme_domain configured either via a `Letsencrypt.configure` block in an initializer or as environment variables." unless Letsencrypt.configuration.valid?
+    abort "letsencrypt-rails-heroku is configured incorrectly. Are you missing an environment variable or other configuration? You should have a heroku_token, heroku_app, acme_email and acme_domain configured either via a `Letsencrypt.configure` block in an initializer or as environment variables." unless Letsencrypt.configuration.valid?
 
     # Set up Heroku client
     heroku = PlatformAPI.connect_oauth Letsencrypt.configuration.heroku_token
@@ -42,17 +42,26 @@ namespace :letsencrypt do
       })
       puts "Done!"
 
-      # Wait for request to go through
-      print "Giving config vars time to change..."
-      sleep(5)
-      puts "Done!"
-
       # Wait for app to come up
       print "Testing filename works (to bring up app)..."
 
       # Get the domain name from Heroku
       hostname = heroku.domain.list(heroku_app).first['hostname']
-      open("http://#{hostname}/#{challenge.filename}").read
+
+      start_time = Time.now
+
+      begin
+        open("http://#{hostname}/#{challenge.filename}").read
+      rescue OpenURI::HTTPError => e
+        if Time.now - start_time <= 30
+          sleep(5)
+          retry
+        else
+          failure_message = "Error waiting for response from http://#{hostname}/#{challenge.filename}, Error: #{e.message}"
+          raise Letsencrypt::Error::ChallengeUrlError, failure_message
+        end
+      end
+
       puts "Done!"
 
       print "Giving LetsEncrypt some time to verify..."
@@ -65,7 +74,8 @@ namespace :letsencrypt do
 
       unless challenge.verify_status == 'valid'
         puts "Problem verifying challenge."
-        abort "Status: #{challenge.verify_status}, Error: #{challenge.error}"
+        failure_message = "Status: #{challenge.verify_status}, Error: #{challenge.error}"
+        raise Letsencrypt::Error::VerificationError, failure_message
       end
 
       puts ""
@@ -85,7 +95,7 @@ namespace :letsencrypt do
     certificate = client.new_certificate(csr) # => #<Acme::Client::Certificate ....>
 
     # Send certificates to Heroku via API
-    
+
     # First check for existing certificates:
     certificates = heroku.sni_endpoint.list(heroku_app)
 
@@ -107,7 +117,7 @@ namespace :letsencrypt do
       end
     rescue Excon::Error::UnprocessableEntity => e
       warn "Error adding certificate to Heroku. Response from Heroku’s API follows:"
-      abort e.response.body
+      raise Letsencrypt::Error::HerokuCertError, e.response.body
     end
 
   end

--- a/lib/tasks/letsencrypt.rake
+++ b/lib/tasks/letsencrypt.rake
@@ -54,6 +54,7 @@ namespace :letsencrypt do
         open("http://#{hostname}/#{challenge.filename}").read
       rescue OpenURI::HTTPError => e
         if Time.now - start_time <= 30
+          puts "Error fetching challenge, retrying... #{e.message}"
           sleep(5)
           retry
         else

--- a/lib/tasks/letsencrypt.rake
+++ b/lib/tasks/letsencrypt.rake
@@ -47,6 +47,9 @@ namespace :letsencrypt do
 
       # Get the domain name from Heroku
       hostname = heroku.domain.list(heroku_app).first['hostname']
+      
+      # Wait at least a little bit, otherwise the first request will almost always fail.
+      sleep(2)
 
       start_time = Time.now
 


### PR DESCRIPTION
This builds upon PR #28 to make use of custom exceptions module.
Implements begin -> rescue -> retry loop: 
- An attempt is made to open the challenge URL.
- If the url is unavailable, the error is rescued and another attempt is made every 5 secs for a maximum of 30 secs. This should be sufficient to allow config variables to update etc.
- If this time limit is reached, a custom error is raised.

Addresses issue #9.

