### PR TITLE
Loops on verifying status of challenge

### DIFF
--- a/lib/letsencrypt-rails-heroku.rb
+++ b/lib/letsencrypt-rails-heroku.rb
@@ -1,5 +1,6 @@
 require 'letsencrypt-rails-heroku/letsencrypt'
 require 'letsencrypt-rails-heroku/middleware'
+require 'letsencrypt-rails-heroku/exceptions'
 
 if defined?(Rails)
   require 'letsencrypt-rails-heroku/railtie'

--- a/lib/letsencrypt-rails-heroku/exceptions.rb
+++ b/lib/letsencrypt-rails-heroku/exceptions.rb
@@ -1,0 +1,10 @@
+module Letsencrypt
+  module Error
+    # Exception raised when LetsEncrypt encounters an issue verifying the challenge.
+    class VerificationError < StandardError; end
+    # Exception raised when an error occurs adding the certificate to Heroku.
+    class HerokuCertError < StandardError; end
+    # Exception raised on timeout of challenge verification.
+    class VerificationTimeoutError < StandardError; end
+  end
+end


### PR DESCRIPTION
Builds upon PR #28 to make use of custom exceptions module.
The challenge status is checked every 3 secs for a maximum of 30 secs. If it is still 'pending' after 30 secs, a custom error is raised.

Addresses issue #6.