### PR TITLE
update README.me on https path to gem 'platform-api'

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the gem to your Gemfile:
 ```
 # Until the new API calls are generally available, you must manually specify my fork
 # of the Heroku API gem:
-gem 'platform-api', github: 'jalada/platform-api', branch: 'master'
+gem 'platform-api', :git => 'https://github.com/jalada/platform-api.git', :branch => 'master'
 
 gem 'letsencrypt-rails-heroku', group: 'production'
 ```


### PR DESCRIPTION
Hi there,

as bundler and Heroku want to have a https source for gems to be downloaded directly from github, why not provide the right path in the readme in the first place.

I hope you like it.

Cheers,
Volker