### PR TITLE
open-uri doesn't raise an HTTPRedirect, just a runtime error

### DIFF
--- a/lib/tasks/letsencrypt.rake
+++ b/lib/tasks/letsencrypt.rake
@@ -62,7 +62,8 @@ namespace :letsencrypt do
 
       begin
         open("http://#{hostname}/#{challenge.filename}").read
-      rescue OpenURI::HTTPError, OpenURI::HTTPRedirect => e
+      rescue OpenURI::HTTPError, RuntimeError => e
+        raise e if e.is_a?(RuntimeError) && !e.message.include?("redirection forbidden")
         if Time.now - start_time <= 60
           puts "Error fetching challenge, retrying... #{e.message}"
           sleep(5)


### PR DESCRIPTION
https://github.com/pixielabs/letsencrypt-rails-heroku/pull/42 was flawed, it wasn't the right type of error to catch.