### PR TITLE
Fixed domain wildcard issues

### DIFF
--- a/lib/letsencrypt-rails-heroku/letsencrypt.rb
+++ b/lib/letsencrypt-rails-heroku/letsencrypt.rb
@@ -9,20 +9,21 @@ module Letsencrypt
   end
 
   def self.challenge_configured?
-    configuration.acme_challenge_filename && 
+    configuration.acme_challenge_filename &&
       configuration.acme_challenge_filename.start_with?(".well-known/") &&
       configuration.acme_challenge_file_content
   end
 
   class Configuration
-    attr_accessor :heroku_token, :heroku_app, :acme_email, :acme_domain, :acme_endpoint
-    
+    attr_accessor :heroku_token, :heroku_app, :heroku_app_domain, :acme_email, :acme_domain, :acme_endpoint
+
     # Not settable by user; part of the gem's behaviour.
     attr_reader :acme_challenge_filename, :acme_challenge_file_content
 
     def initialize
       @heroku_token = ENV["HEROKU_TOKEN"]
       @heroku_app = ENV["HEROKU_APP"]
+      @heroku_app_domain = ENV["HEROKU_APP_DOMAIN"]
       @acme_email = ENV["ACME_EMAIL"]
       @acme_domain = ENV["ACME_DOMAIN"]
       @acme_endpoint = ENV["ACME_ENDPOINT"] || 'https://acme-v01.api.letsencrypt.org/'

--- a/lib/tasks/letsencrypt.rake
+++ b/lib/tasks/letsencrypt.rake
@@ -53,10 +53,18 @@ namespace :letsencrypt do
       print "Testing filename works (to bring up app)..."
 
       # Get the domain name from Heroku
-      heroku_domains = heroku.domain.list(heroku_app)
-      heroku_domain = heroku_domains.find { |heroku_domain_i| !heroku_domain_i["hostname"].start_with?("*.") }
-      raise "Couldn't find domain on Heroku that wasn't a wildcard: #{heroku_domains}" unless heroku_domain
-      hostname = heroku_domain["hostname"]
+      if Letsencrypt.configuration.heroku_app_domain
+        puts "Using hostname from HEROKU_APP_DOMAIN environment variable"
+        hostname = Letsencrypt.configuration.heroku_app_domain
+      else
+        puts "Trying to guess hostname from registered app domains"
+        heroku_domains = heroku.domain.list(heroku_app)
+        heroku_domain = heroku_domains.find { |heroku_domain_i| !heroku_domain_i["hostname"].start_with?("*.") }
+        raise "Couldn't find domain on Heroku that wasn't a wildcard: #{heroku_domains}" unless heroku_domain
+        hostname = heroku_domain["hostname"]
+      end
+
+      puts "Using hostname: #{hostname}"
 
       # Wait at least a little bit, otherwise the first request will almost always fail.
       sleep(2)

--- a/lib/tasks/letsencrypt.rake
+++ b/lib/tasks/letsencrypt.rake
@@ -53,8 +53,11 @@ namespace :letsencrypt do
       print "Testing filename works (to bring up app)..."
 
       # Get the domain name from Heroku
-      hostname = heroku.domain.list(heroku_app).first['hostname']
-      
+      heroku_domains = heroku.domain.list(heroku_app)
+      heroku_domain = heroku_domains.find { |heroku_domain_i| !heroku_domain_i["hostname"].start_with?("*.") }
+      raise "Couldn't find domain on Heroku that wasn't a wildcard: #{heroku_domains}" unless heroku_domain
+      hostname = heroku_domain["hostname"]
+
       # Wait at least a little bit, otherwise the first request will almost always fail.
       sleep(2)
 


### PR DESCRIPTION
Closes #39 

I have implemented two options to fix the wildcard domain issue:

1. The Rake task chooses a domain that isn't a wildcard
2. You can supply the domain you want used through an extra environment variable called `HEROKU_APP_DOMAIN`