### PR TITLE
Support SSL Endpoint SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ which you should set.
  * `ACME_EMAIL`: Your email address, should be valid.
  * `HEROKU_TOKEN`: An API token for this app. See below
  * `HEROKU_APP`: Name of Heroku app e.g. bottomless-cavern-7173
+ * `SSL_ENDPOINT_TYPE`: Optional: One of `sni` or `ssl`, defaults to `sni`. `ssl`
+   requires your app to have an SSL endpoint addon configured.
 
 The gem itself will temporarily create additional environment variables during
 the challenge / validation process:
@@ -179,8 +181,6 @@ Your domain is still configured as a CNAME or ALIAS to `your-app.herokuapp.com`.
 
 - Provide instructions for running the gem decoupled from the app it is 
   securing, for the paranoid.
-
-- Support non-SNI Heroku SSL too.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ which you should set.
  * `ACME_EMAIL`: Your email address, should be valid.
  * `HEROKU_TOKEN`: An API token for this app. See below
  * `HEROKU_APP`: Name of Heroku app e.g. bottomless-cavern-7173
- * `SSL_ENDPOINT_TYPE`: Optional: One of `sni` or `ssl`, defaults to `sni`. `ssl`
-   requires your app to have an SSL endpoint addon configured.
+ * `SSL_TYPE`: Optional: One of `sni` or `endpoint`, defaults to `sni`.
+   `endpoint` requires your app to have an
+   [SSL endpoint addon](https://elements.heroku.com/addons/ssl) configured.
 
 The gem itself will temporarily create additional environment variables during
 the challenge / validation process:

--- a/lib/letsencrypt-rails-heroku/letsencrypt.rb
+++ b/lib/letsencrypt-rails-heroku/letsencrypt.rb
@@ -16,7 +16,7 @@ module Letsencrypt
 
   class Configuration
     attr_accessor :heroku_token, :heroku_app, :acme_email, :acme_domain,
-      :acme_endpoint, :ssl_endpoint_type
+      :acme_endpoint, :ssl_type
     
     # Not settable by user; part of the gem's behaviour.
     attr_reader :acme_challenge_filename, :acme_challenge_file_content
@@ -27,7 +27,7 @@ module Letsencrypt
       @acme_email = ENV["ACME_EMAIL"]
       @acme_domain = ENV["ACME_DOMAIN"]
       @acme_endpoint = ENV["ACME_ENDPOINT"] || 'https://acme-v01.api.letsencrypt.org/'
-      @ssl_endpoint_type = ENV["SSL_ENDPOINT_TYPE"] || 'sni'
+      @ssl_type = ENV["SSL_TYPE"] || 'sni'
       @acme_challenge_filename = ENV["ACME_CHALLENGE_FILENAME"]
       @acme_challenge_file_content = ENV["ACME_CHALLENGE_FILE_CONTENT"]
     end

--- a/lib/letsencrypt-rails-heroku/letsencrypt.rb
+++ b/lib/letsencrypt-rails-heroku/letsencrypt.rb
@@ -15,7 +15,8 @@ module Letsencrypt
   end
 
   class Configuration
-    attr_accessor :heroku_token, :heroku_app, :acme_email, :acme_domain, :acme_endpoint
+    attr_accessor :heroku_token, :heroku_app, :acme_email, :acme_domain,
+      :acme_endpoint, :ssl_endpoint_type
     
     # Not settable by user; part of the gem's behaviour.
     attr_reader :acme_challenge_filename, :acme_challenge_file_content
@@ -26,6 +27,7 @@ module Letsencrypt
       @acme_email = ENV["ACME_EMAIL"]
       @acme_domain = ENV["ACME_DOMAIN"]
       @acme_endpoint = ENV["ACME_ENDPOINT"] || 'https://acme-v01.api.letsencrypt.org/'
+      @ssl_endpoint_type = ENV["SSL_ENDPOINT_TYPE"] || 'sni'
       @acme_challenge_filename = ENV["ACME_CHALLENGE_FILENAME"]
       @acme_challenge_file_content = ENV["ACME_CHALLENGE_FILE_CONTENT"]
     end

--- a/lib/tasks/letsencrypt.rake
+++ b/lib/tasks/letsencrypt.rake
@@ -117,10 +117,10 @@ namespace :letsencrypt do
 
     # Send certificates to Heroku via API
 
-    endpoint = case Letsencrypt.configuration.ssl_endpoint_type
+    endpoint = case Letsencrypt.configuration.ssl_type
                when 'sni'
                  heroku.sni_endpoint
-               when 'ssl'
+               when 'endpoint'
                  heroku.ssl_endpoint
                end
 

--- a/lib/tasks/letsencrypt.rake
+++ b/lib/tasks/letsencrypt.rake
@@ -117,20 +117,27 @@ namespace :letsencrypt do
 
     # Send certificates to Heroku via API
 
+    endpoint = case Letsencrypt.configuration.ssl_endpoint_type
+               when 'sni'
+                 heroku.sni_endpoint
+               when 'ssl'
+                 heroku.ssl_endpoint
+               end
+
     # First check for existing certificates:
-    certificates = heroku.sni_endpoint.list(heroku_app)
+    certificates = endpoint.list(heroku_app)
 
     begin
       if certificates.any?
         print "Updating existing certificate #{certificates[0]['name']}..."
-        heroku.sni_endpoint.update(heroku_app, certificates[0]['name'], {
+        endpoint.update(heroku_app, certificates[0]['name'], {
           certificate_chain: certificate.fullchain_to_pem,
           private_key: certificate.request.private_key.to_pem
         })
         puts "Done!"
       else
         print "Adding new certificate..."
-        heroku.sni_endpoint.create(heroku_app, {
+        endpoint.create(heroku_app, {
           certificate_chain: certificate.fullchain_to_pem,
           private_key: certificate.request.private_key.to_pem
         })


### PR DESCRIPTION
Heroku have two SSL offerings:

1. Free SNI-based SSL, which this gem has always supported.
2. $20/m 'full fat' SSL, which gives you a dedicated IP address.

This change adds an optional configuration variable, `SSL_ENDPOINT_TYPE` which can be one of `sni` or `ssl`, and defaults to `sni`.

This is a minor, backwards compatible API change.