### PR TITLE
Update scheduler code to always load dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ run less frequently using a shell control statement. For example to renew your
 certificate on the 1st day of every month:
 
 ```
-if [ "$(date +%d)" = 01 ]; then rake letsencrypt:renew; fi
+if [ "$(date +%d)" = 01 ]; then bundle exec rake letsencrypt:renew; fi
 ```
 
 Source: [blog.dbrgn.ch](https://blog.dbrgn.ch/2013/10/4/heroku-schedule-weekly-monthly-tasks/)


### PR DESCRIPTION
In Sinatra the dependencies from the Gemfile are not automatically loaded. As a result, the renewal task fails on the scheduler. By prepending `bundle exec` this is resolved.

Closes #56 