### PR TITLE
Update rack, nokogiri, stop using platform-api fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'acme-client', '~> 0.4.0'
 gem 'platform-api', '~> 2.2'

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,8 @@
 source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'acme-client', '~> 0.4.0'
-# SNI endpoints not supported yet:
-# <https://github.com/heroku/platform-api/issues/49>
-gem 'platform-api', github: 'jalada/platform-api', branch: 'master'
+gem 'platform-api'
 
 group :development do
   gem "shoulda", ">= 0"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'acme-client', '~> 0.4.0'
-gem 'platform-api'
+gem 'platform-api', '~> 2.2'
 
 group :development do
   gem "shoulda", ">= 0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: git://github.com/jalada/platform-api.git
-  revision: 45ddb3c1a7e2c7f85d979c0791db18e99affb237
-  branch: master
-  specs:
-    platform-api (0.8.0)
-      heroics (~> 0.0.17)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -23,7 +15,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     docile (1.1.5)
     erubis (2.7.0)
-    excon (0.51.0)
+    excon (0.62.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     git (1.3.0)
@@ -34,15 +26,14 @@ GEM
       hashie (>= 3.4)
       oauth2 (~> 1.0)
     hashie (3.4.6)
-    heroics (0.0.17)
+    heroics (0.0.25)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-      netrc
     highline (1.7.8)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     juwelier (2.1.3)
       builder
       bundler (>= 1.13)
@@ -54,22 +45,24 @@ GEM
       rdoc
       semver
     jwt (1.5.6)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.4.0)
     minitest (5.9.0)
-    moneta (0.8.0)
-    multi_json (1.12.1)
+    moneta (1.0.0)
+    multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    netrc (0.11.0)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.10.2)
+      mini_portile2 (~> 2.4.0)
     oauth2 (1.2.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    rack (2.0.1)
+    platform-api (2.2.0)
+      heroics (~> 0.0.25)
+      moneta (~> 1.0.0)
+    rack (2.0.7)
     rake (12.0.0)
     rdoc (3.12.2)
       json (~> 1.4)
@@ -96,10 +89,10 @@ DEPENDENCIES
   acme-client (~> 0.4.0)
   bundler (~> 1.0)
   juwelier (~> 2.1.0)
-  platform-api!
+  platform-api
   rdoc (~> 3.12)
   shoulda
   simplecov
 
 BUNDLED WITH
-   1.13.6
+   1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ DEPENDENCIES
   acme-client (~> 0.4.0)
   bundler (~> 1.0)
   juwelier (~> 2.1.0)
-  platform-api
+  platform-api (~> 2.2)
   rdoc (~> 3.12)
   shoulda
   simplecov

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ repository.
 
 ## Requirements
 
- - You must be using hobby or professional dynos to use free SNI-based SSL. Find out more on [Heroku's documentation page about SSL](https://devcenter.heroku.com/articles/ssl).
+ - You must be using hobby or professional dynos to use free SNI-based SSL.
+   Find out more on [Heroku's documentation page about
+   SSL](https://devcenter.heroku.com/articles/ssl).
 
  - You should have already configured your app DNS as per [Heroku's
    documentation](https://devcenter.heroku.com/articles/custom-domains).
@@ -27,10 +29,6 @@ repository.
 Add the gem to your Gemfile:
 
 ```
-# Until the new API calls are generally available, you must manually specify my fork
-# of the Heroku API gem:
-gem 'platform-api', git: 'https://github.com/jalada/platform-api', branch: 'master'
-
 gem 'letsencrypt-rails-heroku', group: 'production'
 ```
 
@@ -133,9 +131,9 @@ You should add a scheduled task on Heroku to renew the certificate. If you
 are unfamiliar with how to do this, take a look at [Heroku's documentation
 on their scheduler addon](https://devcenter.heroku.com/articles/scheduler).
 
-The scheduled task should be configured to run `rake letsencrypt:renew` as often
-as you want to renew your certificate. Letsencrypt certificates are valid for
-90 days, but there's no harm renewing them more frequently than that.
+The scheduled task should be configured to run `rake letsencrypt:renew` as
+often as you want to renew your certificate. Letsencrypt certificates are valid
+for 90 days, but there's no harm renewing them more frequently than that.
 
 Heroku Scheduler only lets you run a task as infrequently as once a day, but
 you don't want to renew your SSL certificate every day (you will hit
@@ -154,12 +152,13 @@ Source: [blog.dbrgn.ch](https://blog.dbrgn.ch/2013/10/4/heroku-schedule-weekly-m
 Suggestions and pull requests are welcome in improving the situation with the
 following security considerations:
 
- - When configuring this gem you must add a non-expiring Heroku API token
-   into your application environment. Your collaborators could use this
-   token to impersonate the account it was created with when accessing
-   the Heroku API. This is important if your account has access to other apps
-   that your collaborators don’t. Additionally, if your application environment was
-   leaked this would give the attacker access to the Heroku API as your user account. 
+ - When configuring this gem you must add a non-expiring Heroku API token into
+   your application environment. Your collaborators could use this token to
+   impersonate the account it was created with when accessing the Heroku API.
+   This is important if your account has access to other apps that your
+   collaborators don’t. Additionally, if your application environment was
+   leaked this would give the attacker access to the Heroku API as your user
+   account. 
    [More information about Heroku’s API and oAuth](https://devcenter.heroku.com/articles/oauth#direct-authorization).
 
    You should create the API token from a suitably locked-down account.
@@ -176,17 +175,17 @@ following security considerations:
 
 ### Common name invalid errors (security certificate is from *.herokuapp.com)
 
-Your domain is still configured as a CNAME or ALIAS to `your-app.herokuapp.com`. Check the output of `heroku domains` matches your DNS configuration. When you add an SNI cert to an app for the first time [the DNS target changes](https://devcenter.heroku.com/articles/custom-domains#view-existing-domains).
+Your domain is still configured as a CNAME or ALIAS to
+`your-app.herokuapp.com`. Check the output of `heroku domains` matches your DNS
+configuration. When you add an SNI cert to an app for the first time
+[the DNS target changes](https://devcenter.heroku.com/articles/custom-domains#view-existing-domains).
 
 ## To-do list
 
 - Persist account key, or at least give the option of using an existing one, so
   we don’t register with LetsEncrypt over and over.
 
-- Stop using a fork of the `platform-api` gem once it supports the SNI endpoint
-  API calls. [See issue #49 of the platform-api gem](https://github.com/heroku/platform-api/issues/49).
-
-- Provide instructions for running the gem decoupled from the app it is 
+- Provide instructions for running the gem decoupled from the app it is
   securing, for the paranoid.
 
 ## Contributing
@@ -208,4 +207,5 @@ Your domain is still configured as a CNAME or ALIAS to `your-app.herokuapp.com`.
 
 1. Bump the version: `rake version:bump:{major,minor,patch}`.
 2. Update `CHANGELOG.md` & commit.
-3. Use `rake release` to regenerate gemspec, push a tag to git, and push a new `.gem` to rubygems.org
+3. Use `rake release` to regenerate gemspec, push a tag to git, and push a new
+   `.gem` to rubygems.org.


### PR DESCRIPTION
Update `rack` and `nokogiri` due to a bunch of CVEs:

 * https://nvd.nist.gov/vuln/detail/CVE-2018-16471
 * https://nvd.nist.gov/vuln/detail/CVE-2016-4658
 * https://nvd.nist.gov/vuln/detail/CVE-2017-5029
 * https://nvd.nist.gov/vuln/detail/CVE-2018-14404
 * https://nvd.nist.gov/vuln/detail/CVE-2017-18258
 * https://nvd.nist.gov/vuln/detail/CVE-2017-9050

Additionally, the Heroku platform-api gem now supports API calls for modifying SNI endpoint certificates, so our fork is no longer required.